### PR TITLE
Revert "core/state/snapshot: tiny fixes (#29995)"

### DIFF
--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -631,10 +631,16 @@ func generateAccounts(ctx *generatorContext, dl *diskLayer, accMarker []byte) er
 		accMarker = nil
 		return nil
 	}
+	// Always reset the initial account range as 1 whenever recover from the
+	// interruption. TODO(rjl493456442) can we remove it?
+	var accountRange = accountCheckRange
+	if len(accMarker) > 0 {
+		accountRange = 1
+	}
 	origin := common.CopyBytes(accMarker)
 	for {
 		id := trie.StateTrieID(dl.root)
-		exhausted, last, err := dl.generateRange(ctx, id, rawdb.SnapshotAccountPrefix, snapAccount, origin, accountCheckRange, onAccount, types.FullAccountRLP)
+		exhausted, last, err := dl.generateRange(ctx, id, rawdb.SnapshotAccountPrefix, snapAccount, origin, accountRange, onAccount, types.FullAccountRLP)
 		if err != nil {
 			return err // The procedure it aborted, either by external signal or internal error.
 		}
@@ -646,6 +652,7 @@ func generateAccounts(ctx *generatorContext, dl *diskLayer, accMarker []byte) er
 			ctx.removeStorageLeft()
 			break
 		}
+		accountRange = accountCheckRange
 	}
 	return nil
 }

--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -258,6 +258,14 @@ func (t *Tree) Disable() {
 	for _, layer := range t.layers {
 		switch layer := layer.(type) {
 		case *diskLayer:
+
+			layer.lock.RLock()
+			generating := layer.genMarker != nil
+			layer.lock.RUnlock()
+			if !generating {
+				// Generator is already aborted or finished
+				break
+			}
 			// If the base layer is generating, abort it
 			if layer.genAbort != nil {
 				abort := make(chan *generatorStats)
@@ -268,7 +276,6 @@ func (t *Tree) Disable() {
 			layer.lock.Lock()
 			layer.stale = true
 			layer.lock.Unlock()
-			layer.Release()
 
 		case *diffLayer:
 			// If the layer is a simple diff, simply mark as stale
@@ -733,7 +740,6 @@ func (t *Tree) Rebuild(root common.Hash) {
 			layer.lock.Lock()
 			layer.stale = true
 			layer.lock.Unlock()
-			layer.Release()
 
 		case *diffLayer:
 			// If the layer is a simple diff, simply mark as stale


### PR DESCRIPTION
### Description

In this pull request, the following changes were made across two files:

1. In the file `core/state/snapshot/generate.go`:
   - Added condition to reset the initial account range to 1 when recovering from interruption.
   - Updated the function parameters `accountCheckRange` to `accountRange` within the `generateRange` function call.
   - Added a condition to reset `accountRange` back to `accountCheckRange` within a loop.

2. In the file `core/state/snapshot/snapshot.go`:
   - Added a check before aborting the generator to ensure that it is not already finished.
   - Removed the `layer.Release()` call after marking a layer as stale in the `Disable()` and `Rebuild()` functions.

These changes aim to improve the behavior of account range generation during snapshot recovery and ensure proper handling of the generator state in the snapshot tree.

If you have any feedback or questions regarding these changes, please feel free to share.