### PR TITLE
core/tracing: update latest release version

### DIFF
--- a/core/tracing/CHANGELOG.md
+++ b/core/tracing/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the tracing interface will be documented in this file.
 
-## [Unreleased]
+## [v1.14.3]
 
 There have been minor backwards-compatible changes to the tracing interface to explicitly mark the execution of **system** contracts. As of now the only system call updates the parent beacon block root as per [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788). Other system calls are being considered for the future hardfork.
 
@@ -77,3 +77,4 @@ The hooks `CaptureStart` and `CaptureEnd` have been removed. These hooks signale
 
 [unreleased]: https://github.com/ethereum/go-ethereum/compare/v1.14.0...master
 [v1.14.0]: https://github.com/ethereum/go-ethereum/releases/tag/v1.14.0
+[v1.14.3]: https://github.com/ethereum/go-ethereum/releases/tag/v1.14.3


### PR DESCRIPTION
### Description

In this pull request, the `CHANGELOG.md` file in the `core/tracing` directory has been modified to document changes to the tracing interface.

Changes in this pull request:
- Updated the section header to indicate the version [v1.14.3] instead of [Unreleased].
- Added a link for version [v1.14.3] to associate it with a specific release.

This pull request updates the release version in the CHANGELOG.md file for the tracing interface.

No code changes were made, only modifications to the documentation.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the CHANGELOG.md to document the latest release version v1.14.3 for the tracing interface, including a link to the specific release.

Documentation:
- Update the CHANGELOG.md file in the core/tracing directory to reflect the latest release version v1.14.3, replacing the previous 'Unreleased' section header.

<!-- Generated by sourcery-ai[bot]: end summary -->